### PR TITLE
fix bug and change error to warning

### DIFF
--- a/src/ai/OpenAICaller.ts
+++ b/src/ai/OpenAICaller.ts
@@ -83,6 +83,7 @@ export class OpenAICaller implements APICaller {
             };
             return feedback;
         }, async(_) => {
+            done = true;
             const answer = await vscode.window.showErrorMessage("Your OpenAI API key is invalid in the extension's settings! Please correct it before continuing.", "Go To Settings");
             if(answer === "Go To Settings") {
                 vscode.env.openExternal(vscode.Uri.parse("vscode://settings/drDebug.apiKey"));
@@ -92,7 +93,7 @@ export class OpenAICaller implements APICaller {
 
         if(errorFeedback.problemFiles.length === 0) {
             done = true;
-            await vscode.window.showErrorMessage("An error could not be found in the terminal. Please try again.");
+            await vscode.window.showWarningMessage("An error could not be found in the terminal. Please try again.");
             return Promise.reject();
         }
         


### PR DESCRIPTION
Fixed the progress bar bug, and changed the showInformationMessage to showWarningMessage. I don't think there is a way to do a green check like malachowsky suggested, but I'm not sure that would be correct since they should only intend to use the debugger when they think there is an error. I think warning is more fitting than error though since usually there is nothing actually wrong when it triggers.